### PR TITLE
Add include_docs option to getAllDocs() method.

### DIFF
--- a/lib/src/models/database_model.dart
+++ b/lib/src/models/database_model.dart
@@ -86,11 +86,11 @@ class DatabaseModel extends DatabaseBaseModel {
   }
 
   @override
-  Future<DbResponse> getAllDocs(String dbName) async {
+  Future<DbResponse> getAllDocs(String dbName, {bool include_docs = false}) async {
     DbResponse result;
 
     try {
-      result = await client.get('$dbName/_all_docs');
+      result = await client.get('$dbName/_all_docs?include_docs=$include_docs');
     } on CouchDbException {
       rethrow;
     }


### PR DESCRIPTION
This option will include the full content of any documents fetched with getAllDocs() rather than just the id and rev.