### PR TITLE
API changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,10 @@ Local documents are no different than normal documents, with the exception that 
 
 ### CORS
 
-If your application aren't on the same origin with CouchDB instance or you using different ports on server, then the remote CouchDB must be configured with the following options:
+CORS is a method of enabling a web app to talk to a server other than the server hosting it. It is only nessesary if the applicationn is running in the browser.
+
+#### CouchDB Server Configuration for CORS
+If the application isn't on the same origin with CouchDB instance (or you using different ports on server), then the remote CouchDB must be configured with the following options:
 
     [httpd]
     enable_cors = true
@@ -125,7 +128,10 @@ If your application aren't on the same origin with CouchDB instance or you using
     methods = GET, PUT, POST, HEAD, DELETE, COPY
     headers = accept, authorization, content-type, origin, referer, x-csrf-token
 
-(Change these settings either in Fauxton or in the local.ini file).
+Change these settings either in Fauxton configuration utility or in the CouchDb local.ini file. For better security, specify specific domains instead of * in the `origins` section.
+
+#### Browser Client Configuration for CORS
+Depending on the browser, you might also need to pass `cors=true` to the `CouchBdClient` constructor. However, most of the time the browser will handle this for you and this shouldn't be nessesary. In fact, it might cause an "Unsafe Header" message in the browser console.
 
 ## Usage
 
@@ -140,14 +146,13 @@ Future<void> main() async {
   final docModel = DocumentModel(client);
 
   try {
-    final DbResponse commonResponse = await dbModel.allDocs('some_db');
-    final DatabaseModelResponse response1 = commonResponse.databaseModelResponse();
+    final DatabaseModelResponse response1 = await dbModel.allDocs('some_db');
 
     for (var i in response1.rows) {
       // Some code here
     }
 
-    final DbResponse response2 = await docModel.doc('another_db', 'some_id');
+    final DocumentModelResponse response2 = await docModel.doc('another_db', 'some_id');
 
     var thing = response2.json['some_attribute'];
 

--- a/example/README.md
+++ b/example/README.md
@@ -9,16 +9,15 @@ Future<void> main() async {
   final docModel = DocumentModel(client)
 
   try {
-    final DbResponse commonResponse = await dbModel.allDocs('some_db');
-    final DatabaseModelResponse response1 = commonResponse.databaseModelResponse();
+    final DatabaseModelResponse response1 = await dbModel.allDocs('some_db');
 
     for (var i in response1.rows) {
       // Some code here
     }
 
-    final DbResponse response2 = await docModel.doc('another_db', 'some_id');
+    final DocumentModelResponse response2 = await docModel.doc('another_db', 'some_id');
 
-    var thing = response2.json['some_attribute'];
+    var thing = response2.doc['some_attribute'];
 
   } on CouchDbException catch (e) {
     print('$e - error');
@@ -42,8 +41,7 @@ Future<void> main(List<String> args) async {
 
   btn.onClick.listen((event) async {
   try {
-    final DbResponse commonResponse = await dbModel.doc('some_db', 'some_doc_id');
-    final DocumentModelResponse response1 = commonResponse.documentModelResponse();
+    final DocumentModelResponse response1 = await dbModel.doc('some_db', 'some_doc_id');
 
     final Map<String, Object> doc = response1.doc;
 

--- a/lib/src/models/base/database_base_model.dart
+++ b/lib/src/models/base/database_base_model.dart
@@ -2,6 +2,7 @@ import 'package:meta/meta.dart';
 
 import '../../clients/couchdb_client.dart';
 import '../../entities/db_response.dart';
+import '../../entities/database_model_response.dart';
 import 'base_model.dart';
 
 /// Class that define methods for interacting with entire database in CouchDB
@@ -11,7 +12,7 @@ abstract class DatabaseBaseModel extends BaseModel {
 
   /// Returns the HTTP Headers containing a minimal amount of information
   /// about the specified database
-  Future<DbResponse> headDbInfo(String dbName);
+  Future<DatabaseModelResponse> headDbInfo(String dbName);
 
   /// Gets information about the specified database
   ///
@@ -44,7 +45,7 @@ abstract class DatabaseBaseModel extends BaseModel {
   ///     "update_seq": "292786-g1AAAAF..."
   /// }
   /// ```
-  Future<DbResponse> dbInfo(String dbName);
+  Future<DatabaseModelResponse> dbInfo(String dbName);
 
   /// Creates a new database
   ///
@@ -56,7 +57,7 @@ abstract class DatabaseBaseModel extends BaseModel {
   /// ```
   ///
   /// Otherwise error response is returned.
-  Future<DbResponse> createDb(String dbName, {int q = 8});
+  Future<DatabaseModelResponse> createDb(String dbName, {int q = 8});
 
   /// Deletes the specified database, and all the documents and attachments contained within it
   ///
@@ -68,7 +69,7 @@ abstract class DatabaseBaseModel extends BaseModel {
   /// ```
   ///
   /// Otherwise error response is returned.
-  Future<DbResponse> deleteDb(String dbName);
+  Future<DatabaseModelResponse> deleteDb(String dbName);
 
   /// Creates a new document in the specified database, using the supplied JSON document structure
   ///
@@ -80,7 +81,7 @@ abstract class DatabaseBaseModel extends BaseModel {
   ///     "rev": "1-9c65296036141e575d32ba9c034dd3ee"
   /// }
   /// ```
-  Future<DbResponse> createDocIn(String dbName, Map<String, Object> doc,
+  Future<DatabaseModelResponse> createDocIn(String dbName, Map<String, Object> doc,
       {String batch, Map<String, String> headers});
 
   /// Executes the built-in _all_docs view, returning all of the documents in the database
@@ -108,7 +109,7 @@ abstract class DatabaseBaseModel extends BaseModel {
   ///     "total_rows": 2
   /// }
   /// ```
-  Future<DbResponse> allDocs(String dbName, {bool includeDocs = false});
+  Future<DatabaseModelResponse> allDocs(String dbName, {bool includeDocs = false});
 
   /// Executes the built-in _all_docs view, returning specified documents in the database
   ///
@@ -138,7 +139,7 @@ abstract class DatabaseBaseModel extends BaseModel {
   ///     "total_rows": 2453
   /// }
   /// ```
-  Future<DbResponse> docsByKeys(String dbName, {List<String> keys});
+  Future<DatabaseModelResponse> docsByKeys(String dbName, {List<String> keys});
 
   /// Returns a JSON structure of all of the design documents in a given database
   ///
@@ -165,7 +166,7 @@ abstract class DatabaseBaseModel extends BaseModel {
   ///     "total_rows": 2
   /// }
   /// ```
-  Future<DbResponse> allDesignDocs(String dbName,
+  Future<DatabaseModelResponse> allDesignDocs(String dbName,
       {bool conflicts = false,
       bool descending = false,
       String endKey,
@@ -208,7 +209,7 @@ abstract class DatabaseBaseModel extends BaseModel {
   ///     "total_rows": 6
   /// }
   /// ```
-  Future<DbResponse> designDocsByKeys(String dbName, List<String> keys);
+  Future<DatabaseModelResponse> designDocsByKeys(String dbName, List<String> keys);
 
   /// Executes multiple specified built-in view queries of all documents in this database
   ///
@@ -269,7 +270,7 @@ abstract class DatabaseBaseModel extends BaseModel {
   ///     ]
   /// }
   /// ```
-  Future<DbResponse> queriesDocsFrom(
+  Future<DatabaseModelResponse> queriesDocsFrom(
       String dbName, List<Map<String, Object>> queries);
 
   /// Queries several documents in bulk
@@ -339,7 +340,7 @@ abstract class DatabaseBaseModel extends BaseModel {
   ///   ]
   /// }
   /// ```
-  Future<DbResponse> bulkDocs(String dbName, List<Object> docs,
+  Future<DatabaseModelResponse> bulkDocs(String dbName, List<Object> docs,
       {@required bool revs});
 
   /// Creates and updates multiple documents at the same time within a single request
@@ -359,7 +360,7 @@ abstract class DatabaseBaseModel extends BaseModel {
   ///     }
   /// ]
   /// ```
-  Future<DbResponse> insertBulkDocs(String dbName, List<Object> docs,
+  Future<DatabaseModelResponse> insertBulkDocs(String dbName, List<Object> docs,
       {bool newEdits = true, Map<String, String> headers});
 
   /// Find documents using a declarative JSON querying syntax
@@ -390,7 +391,7 @@ abstract class DatabaseBaseModel extends BaseModel {
   ///     }
   /// }
   /// ```
-  Future<DbResponse> find(String dbName, Map<String, Object> selector,
+  Future<DatabaseModelResponse> find(String dbName, Map<String, Object> selector,
       {int limit = 25,
       int skip,
       List<Object> sort,
@@ -413,7 +414,7 @@ abstract class DatabaseBaseModel extends BaseModel {
   ///     "name": "foo-index"
   /// }
   /// ```
-  Future<DbResponse> createIndexIn(String dbName,
+  Future<DatabaseModelResponse> createIndexIn(String dbName,
       {@required List<String> indexFields,
       String ddoc,
       String name,
@@ -454,7 +455,7 @@ abstract class DatabaseBaseModel extends BaseModel {
   ///   ]
   /// }
   /// ```
-  Future<DbResponse> indexesAt(String dbName);
+  Future<DatabaseModelResponse> indexesAt(String dbName);
 
   /// Delets index in the database
   ///
@@ -464,7 +465,7 @@ abstract class DatabaseBaseModel extends BaseModel {
   ///     "ok": "true"
   /// }
   /// ```
-  Future<DbResponse> deleteIndexIn(
+  Future<DatabaseModelResponse> deleteIndexIn(
       String dbName, String designDoc, String name);
 
   /// Shows which index is being used by the query
@@ -525,7 +526,7 @@ abstract class DatabaseBaseModel extends BaseModel {
   ///     }
   /// }
   /// ```
-  Future<DbResponse> explain(String dbName, Map<String, Object> selector,
+  Future<DatabaseModelResponse> explain(String dbName, Map<String, Object> selector,
       {int limit = 25,
       int skip,
       List<Object> sort,
@@ -558,7 +559,7 @@ abstract class DatabaseBaseModel extends BaseModel {
   ///   }
   /// }
   /// ```
-  Future<DbResponse> shards(String dbName);
+  Future<DatabaseModelResponse> shards(String dbName);
 
   /// Returns information about the specific shard into which a given document
   /// has been stored, along with information about the nodes on which that
@@ -575,7 +576,7 @@ abstract class DatabaseBaseModel extends BaseModel {
   ///   ]
   /// }
   /// ```
-  Future<DbResponse> shard(String dbName, String docId);
+  Future<DatabaseModelResponse> shard(String dbName, String docId);
 
   /// For the given database, force-starts internal shard synchronization
   /// for all replicas of all database shards
@@ -589,7 +590,7 @@ abstract class DatabaseBaseModel extends BaseModel {
   ///     "ok": true
   /// }
   /// ```
-  Future<DbResponse> synchronizeShards(String dbName);
+  Future<DatabaseModelResponse> synchronizeShards(String dbName);
 
   /// Returns a sorted list of changes made to documents in the database
   ///
@@ -727,7 +728,7 @@ abstract class DatabaseBaseModel extends BaseModel {
   ///     "ok": true
   /// }
   /// ```
-  Future<DbResponse> compact(String dbName);
+  Future<DatabaseModelResponse> compact(String dbName);
 
   /// Compacts the view indexes associated with the specified design document
   ///
@@ -737,7 +738,7 @@ abstract class DatabaseBaseModel extends BaseModel {
   ///     "ok": true
   /// }
   /// ```
-  Future<DbResponse> compactViewIndexesWith(String dbName, String ddocName);
+  Future<DatabaseModelResponse> compactViewIndexesWith(String dbName, String ddocName);
 
   /// Commits any recent changes to the specified database to disk
   ///
@@ -749,7 +750,7 @@ abstract class DatabaseBaseModel extends BaseModel {
   ///     "ok": true
   /// }
   /// ```
-  Future<DbResponse> ensureFullCommit(String dbName);
+  Future<DatabaseModelResponse> ensureFullCommit(String dbName);
 
   /// Removes view index files that are no longer required by CouchDB as a result of changed views within design documents
   ///
@@ -759,7 +760,7 @@ abstract class DatabaseBaseModel extends BaseModel {
   ///     "ok": true
   /// }
   /// ```
-  Future<DbResponse> viewCleanup(String dbName);
+  Future<DatabaseModelResponse> viewCleanup(String dbName);
 
   /// Returns the current security object from the specified database
   ///
@@ -785,7 +786,7 @@ abstract class DatabaseBaseModel extends BaseModel {
   ///     }
   /// }
   /// ```
-  Future<DbResponse> securityOf(String dbName);
+  Future<DatabaseModelResponse> securityOf(String dbName);
 
   /// Sets the security object for the given database
   ///
@@ -795,7 +796,7 @@ abstract class DatabaseBaseModel extends BaseModel {
   ///     "ok": true
   /// }
   /// ```
-  Future<DbResponse> setSecurityFor(
+  Future<DatabaseModelResponse> setSecurityFor(
       String dbName, Map<String, Map<String, List<String>>> security);
 
   /// Permanently removes the references to deleted documents from the database
@@ -813,7 +814,7 @@ abstract class DatabaseBaseModel extends BaseModel {
   ///   }
   /// }
   /// ```
-  Future<DbResponse> purge(String dbName, Map<String, List<String>> docs);
+  Future<DatabaseModelResponse> purge(String dbName, Map<String, List<String>> docs);
 
   /// Gets the current purged_infos_limit (purged documents limit) setting,
   /// the maximum number of historical purges (purged document Ids with their revisions)
@@ -823,7 +824,7 @@ abstract class DatabaseBaseModel extends BaseModel {
   /// ```json
   /// 1000
   /// ```
-  Future<DbResponse> purgedInfosLimit(String dbName);
+  Future<DatabaseModelResponse> purgedInfosLimit(String dbName);
 
   /// Sets the maximum number of purges (requested purged Ids with their revisions)
   /// that will be tracked in the database, even after compaction has occurred
@@ -834,7 +835,7 @@ abstract class DatabaseBaseModel extends BaseModel {
   ///     "ok": true
   /// }
   /// ```
-  Future<DbResponse> setPurgedInfosLimit(String dbName, int limit);
+  Future<DatabaseModelResponse> setPurgedInfosLimit(String dbName, int limit);
 
   /// Returns the document revisions that do not exist in the database
   ///
@@ -848,7 +849,7 @@ abstract class DatabaseBaseModel extends BaseModel {
   ///     }
   /// }
   /// ```
-  Future<DbResponse> missingRevs(String dbName, Map<String, List<String>> revs);
+  Future<DatabaseModelResponse> missingRevs(String dbName, Map<String, List<String>> revs);
 
   /// Returns the subset of those that do not correspond to revisions stored in the database
   ///
@@ -866,7 +867,7 @@ abstract class DatabaseBaseModel extends BaseModel {
   ///     }
   /// }
   /// ```
-  Future<DbResponse> revsDiff(String dbName, Map<String, List<String>> revs);
+  Future<DatabaseModelResponse> revsDiff(String dbName, Map<String, List<String>> revs);
 
   /// Gets the current **revs_limit** (revision limit) setting
   ///
@@ -874,7 +875,7 @@ abstract class DatabaseBaseModel extends BaseModel {
   /// ```json
   /// 1000
   /// ```
-  Future<DbResponse> revsLimitOf(String dbName);
+  Future<DatabaseModelResponse> revsLimitOf(String dbName);
 
   /// Sets the maximum number of document revisions that will be tracked by CouchDB, even after compaction has occurred
   ///
@@ -884,5 +885,5 @@ abstract class DatabaseBaseModel extends BaseModel {
   ///     "ok": true
   /// }
   /// ```
-  Future<DbResponse> setRevsLimit(String dbName, int limit);
+  Future<DatabaseModelResponse> setRevsLimit(String dbName, int limit);
 }

--- a/lib/src/models/base/design_document_base_model.dart
+++ b/lib/src/models/base/design_document_base_model.dart
@@ -2,6 +2,7 @@ import 'package:meta/meta.dart';
 
 import '../../clients/couchdb_client.dart';
 import '../../entities/db_response.dart';
+import '../../entities/design_document_model_response.dart';
 import 'base_model.dart';
 
 /// Class that contains methods that allow operate with design documents
@@ -10,7 +11,7 @@ abstract class DesignDocumentBaseModel extends BaseModel {
   DesignDocumentBaseModel(CouchDbClient client) : super(client);
 
   /// Returns the HTTP Headers containing a minimal amount of information about the specified design document
-  Future<DbResponse> designDocHeaders(String dbName, String ddocId,
+  Future<DesignDocumentModelResponse> designDocHeaders(String dbName, String ddocId,
       {Map<String, String> headers,
       bool attachments = false,
       bool attEncodingInfo = false,
@@ -27,7 +28,7 @@ abstract class DesignDocumentBaseModel extends BaseModel {
 
   /// Returns the contents of the design document specified with the name of the design document and
   /// from the specified database
-  Future<DbResponse> designDoc(String dbName, String ddocId,
+  Future<DesignDocumentModelResponse> designDoc(String dbName, String ddocId,
       {Map<String, String> headers,
       bool attachments = false,
       bool attEncodingInfo = false,
@@ -59,7 +60,7 @@ abstract class DesignDocumentBaseModel extends BaseModel {
   /// Note, that for `filters`, `lists`, `shows` and `updates` fields objects are mapping of function name to string function
   /// source code. For `views` mapping is the same except that values are objects with `map` and `reduce` (optional) keys
   /// which also contains functions source code.
-  Future<DbResponse> insertDesignDoc(
+  Future<DesignDocumentModelResponse> insertDesignDoc(
       String dbName, String ddocId, Map<String, Object> body,
       {Map<String, String> headers,
       String rev,
@@ -67,32 +68,32 @@ abstract class DesignDocumentBaseModel extends BaseModel {
       bool newEdits = true});
 
   /// Deletes the specified document from the database
-  Future<DbResponse> deleteDesignDoc(String dbName, String ddocId, String rev,
+  Future<DesignDocumentModelResponse> deleteDesignDoc(String dbName, String ddocId, String rev,
       {Map<String, String> headers, String batch});
 
   /// Copies an existing design document to a new or existing one
-  Future<DbResponse> copyDesignDoc(String dbName, String ddocId,
+  Future<DesignDocumentModelResponse> copyDesignDoc(String dbName, String ddocId,
       {Map<String, String> headers, String rev, String batch});
 
   /// Returns the HTTP headers containing a minimal amount of information about the specified attachment
-  Future<DbResponse> attachmentInfo(
+  Future<DesignDocumentModelResponse> attachmentInfo(
       String dbName, String ddocId, String attName,
       {Map<String, String> headers, String rev});
 
   /// Returns the file attachment associated with the design document
-  Future<DbResponse> attachment(String dbName, String ddocId, String attName,
+  Future<DesignDocumentModelResponse> attachment(String dbName, String ddocId, String attName,
       {Map<String, String> headers, String rev});
 
   /// Uploads the supplied content as an attachment to the specified design document
   ///
   /// You must supply the `Content-Type` header, and for an existing document
   /// you must also supply either the [rev] query argument or the `If-Match` HTTP header
-  Future<DbResponse> uploadAttachment(
+  Future<DesignDocumentModelResponse> uploadAttachment(
       String dbName, String ddocId, String attName, Object body,
       {Map<String, String> headers, String rev});
 
   /// Deletes the attachment of the specified design document
-  Future<DbResponse> deleteAttachment(
+  Future<DesignDocumentModelResponse> deleteAttachment(
       String dbName, String ddocId, String attName,
       {@required String rev, Map<String, String> headers, String batch});
 
@@ -117,7 +118,7 @@ abstract class DesignDocumentBaseModel extends BaseModel {
   ///     }
   /// }
   /// ```
-  Future<DbResponse> designDocInfo(String dbName, String ddocId,
+  Future<DesignDocumentModelResponse> designDocInfo(String dbName, String ddocId,
       {Map<String, String> headers});
 
   /// Executes the specified view function from the specified design document
@@ -152,7 +153,7 @@ abstract class DesignDocumentBaseModel extends BaseModel {
   ///     "total_rows": 3
   /// }
   /// ```
-  Future<DbResponse> executeViewFunction(
+  Future<DesignDocumentModelResponse> executeViewFunction(
       String dbName, String ddocId, String viewName,
       {bool conflicts = false,
       bool descending = false,
@@ -202,7 +203,7 @@ abstract class DesignDocumentBaseModel extends BaseModel {
   ///     "total_rows": 3
   /// }
   /// ```
-  Future<DbResponse> executeViewFunctionWithKeys(
+  Future<DesignDocumentModelResponse> executeViewFunctionWithKeys(
       String dbName, String ddocId, String viewName,
       {@required List<Object> keys,
       bool conflicts = false,
@@ -291,7 +292,7 @@ abstract class DesignDocumentBaseModel extends BaseModel {
   ///     ]
   /// }
   /// ```
-  Future<DbResponse> executeViewQueries(
+  Future<DesignDocumentModelResponse> executeViewQueries(
       String dbName, String ddocId, String viewName, List<Object> queries);
 
   /// Applies show function for null document
@@ -300,7 +301,7 @@ abstract class DesignDocumentBaseModel extends BaseModel {
   ///
   /// `some data that returned by show function`
   ///
-  Future<DbResponse> executeShowFunctionForNull(
+  Future<DesignDocumentModelResponse> executeShowFunctionForNull(
       String dbName, String ddocId, String funcName,
       {String format});
 
@@ -310,7 +311,7 @@ abstract class DesignDocumentBaseModel extends BaseModel {
   ///
   /// `some data that returned by show function`
   ///
-  Future<DbResponse> executeShowFunctionForDocument(
+  Future<DesignDocumentModelResponse> executeShowFunctionForDocument(
       String dbName, String ddocId, String funcName, String docId,
       {String format});
 
@@ -320,7 +321,7 @@ abstract class DesignDocumentBaseModel extends BaseModel {
   ///
   /// `some data that returned by show function`
   ///
-  Future<DbResponse> executeListFunctionForView(
+  Future<DesignDocumentModelResponse> executeListFunctionForView(
       String dbName, String ddocId, String funcName, String view,
       {String format});
 
@@ -330,7 +331,7 @@ abstract class DesignDocumentBaseModel extends BaseModel {
   ///
   /// `some data that returned by show function`
   ///
-  Future<DbResponse> executeListFunctionForViewFromDoc(String dbName,
+  Future<DesignDocumentModelResponse> executeListFunctionForViewFromDoc(String dbName,
       String ddocId, String funcName, String otherDoc, String view,
       {String format});
 
@@ -341,16 +342,16 @@ abstract class DesignDocumentBaseModel extends BaseModel {
   /// {"status": "ok"}
   /// ```
   /// for success exucution or error for fail.
-  Future<DbResponse> executeUpdateFunctionForNull(
+  Future<DesignDocumentModelResponse> executeUpdateFunctionForNull(
       String dbName, String ddocId, String funcName, Object body);
 
   /// Executes update function on server side for the specified document
-  Future<DbResponse> executeUpdateFunctionForDocument(
+  Future<DesignDocumentModelResponse> executeUpdateFunctionForDocument(
       String dbName, String ddocId, String funcName, String docId, Object body);
 
   /// Rewrites the specified path by rules defined in the specified design document
   ///
   /// The rewrite rules are defined by the `rewrites` field of the design document.
   /// The `rewrites` field can either be a string containing the a rewrite function or an array of rule definitions.
-  Future<DbResponse> rewritePath(String dbName, String ddocId, String path);
+  Future<DesignDocumentModelResponse> rewritePath(String dbName, String ddocId, String path);
 }

--- a/lib/src/models/base/document_base_model.dart
+++ b/lib/src/models/base/document_base_model.dart
@@ -11,7 +11,7 @@ abstract class DocumentBaseModel extends BaseModel {
   DocumentBaseModel(CouchDbClient client) : super(client);
 
   /// Returns the HTTP Headers containing a minimal amount of information about the specified document
-  Future<DbResponse> docInfo(String dbName, String docId,
+  Future<DocumentModelResponse> docInfo(String dbName, String docId,
       {Map<String, String> headers,
       bool attachments = false,
       bool attEncodingInfo = false,
@@ -42,7 +42,7 @@ abstract class DocumentBaseModel extends BaseModel {
   ///     "name": "Spaghetti with meatballs"
   /// }
   /// ```
-  Future<DbResponse> doc(String dbName, String docId,
+  Future<DocumentModelResponse> doc(String dbName, String docId,
       {Map<String, String> headers,
       bool attachments = false,
       bool attEncodingInfo = false,
@@ -67,7 +67,7 @@ abstract class DocumentBaseModel extends BaseModel {
   ///     "rev": "1-917fa2381192822767f010b95b45325b"
   /// }
   /// ```
-  Future<DbResponse> insertDoc(
+  Future<DocumentModelResponse> insertDoc(
       String dbName, String docId, Map<String, Object> body,
       {Map<String, String> headers,
       String rev,
@@ -84,7 +84,7 @@ abstract class DocumentBaseModel extends BaseModel {
   ///     "rev": "1-917fa2381192822767f010b95b45325b"
   /// }
   /// ```
-  Future<DbResponse> deleteDoc(String dbName, String docId, String rev,
+  Future<DocumentModelResponse> deleteDoc(String dbName, String docId, String rev,
       {Map<String, String> headers, String batch});
 
   /// Copies an existing document to a new or existing document
@@ -97,17 +97,17 @@ abstract class DocumentBaseModel extends BaseModel {
   ///     "rev": "1-917fa2381192822767f010b95b45325b"
   /// }
   /// ```
-  Future<DbResponse> copyDoc(String dbName, String docId,
+  Future<DocumentModelResponse> copyDoc(String dbName, String docId,
       {Map<String, String> headers, String rev, String batch});
 
   /// Returns the HTTP headers containing a minimal amount of information about the specified attachment
-  Future<DbResponse> attachmentInfo(String dbName, String docId, String attName,
+  Future<DocumentModelResponse> attachmentInfo(String dbName, String docId, String attName,
       {Map<String, String> headers, String rev});
 
   /// Returns the file attachment associated with the document
   ///
   /// Result is available in [DocumentModelResponse.attachment] or [DbResponse.raw] field as bytes of data.
-  Future<DbResponse> attachment(String dbName, String docId, String attName,
+  Future<DocumentModelResponse> attachment(String dbName, String docId, String attName,
       {Map<String, String> headers, String rev});
 
   /// Uploads the supplied content as an attachment to the specified document
@@ -123,7 +123,7 @@ abstract class DocumentBaseModel extends BaseModel {
   ///     "rev": "1-917fa2381192822767f010b95b45325b"
   /// }
   /// ```
-  Future<DbResponse> uploadAttachment(
+  Future<DocumentModelResponse> uploadAttachment(
       String dbName, String docId, String attName, Object body,
       {Map<String, String> headers, String rev});
 
@@ -137,7 +137,7 @@ abstract class DocumentBaseModel extends BaseModel {
   ///     "rev": "1-917fa2381192822767f010b95b45325b"
   /// }
   /// ```
-  Future<DbResponse> deleteAttachment(
+  Future<DocumentModelResponse> deleteAttachment(
       String dbName, String docId, String attName,
       {@required String rev, Map<String, String> headers, String batch});
 }

--- a/lib/src/models/base/local_document_base_model.dart
+++ b/lib/src/models/base/local_document_base_model.dart
@@ -2,6 +2,7 @@ import 'package:meta/meta.dart';
 
 import '../../clients/couchdb_client.dart';
 import '../../entities/db_response.dart';
+import '../../entities/local_document_model_response.dart';
 import 'base_model.dart';
 
 /// The Local (non-replicating) document interface allows to create local documents
@@ -58,7 +59,7 @@ abstract class LocalDocumentBaseModel extends BaseModel {
   ///     "total_rows": null
   /// }
   /// ```
-  Future<DbResponse> localDocs(String dbName,
+  Future<LocalDocumentModelResponse> localDocs(String dbName,
       {bool conflicts = false,
       bool descending = false,
       String endKey,
@@ -99,7 +100,7 @@ abstract class LocalDocumentBaseModel extends BaseModel {
   ///     "offset" : null
   /// }
   /// ```
-  Future<DbResponse> localDocsWithKeys(String dbName,
+  Future<LocalDocumentModelResponse> localDocsWithKeys(String dbName,
       {@required List<String> keys,
       bool conflicts = false,
       bool descending = false,
@@ -117,7 +118,7 @@ abstract class LocalDocumentBaseModel extends BaseModel {
   /// Gets the specified local document
   ///
   /// [docId] must match pattern - `_local/{id}`
-  Future<DbResponse> localDoc(String dbName, String docId,
+  Future<LocalDocumentModelResponse> localDoc(String dbName, String docId,
       {Map<String, String> headers,
       bool conflicts = false,
       bool deletedConflicts = false,
@@ -132,7 +133,7 @@ abstract class LocalDocumentBaseModel extends BaseModel {
   /// Stores the specified local document
   ///
   /// [docId] must match pattern - `_local/{id}`
-  Future<DbResponse> putLocalDoc(
+  Future<LocalDocumentModelResponse> putLocalDoc(
       String dbName, String docId, Map<String, Object> body,
       {Map<String, String> headers,
       String rev,
@@ -142,12 +143,12 @@ abstract class LocalDocumentBaseModel extends BaseModel {
   /// Deletes the specified local document
   ///
   /// [docId] must match pattern - `_local/{id}`
-  Future<DbResponse> deleteLocalDoc(String dbName, String docId, String rev,
+  Future<LocalDocumentModelResponse> deleteLocalDoc(String dbName, String docId, String rev,
       {Map<String, String> headers, String batch});
 
   /// Copies the specified local document
   ///
   /// [docId] must match pattern - `_local/{id}`
-  Future<DbResponse> copyLocalDoc(String dbName, String docId,
+  Future<LocalDocumentModelResponse> copyLocalDoc(String dbName, String docId,
       {Map<String, String> headers, String rev, String batch});
 }

--- a/lib/src/models/base/server_base_model.dart
+++ b/lib/src/models/base/server_base_model.dart
@@ -2,6 +2,7 @@ import 'package:meta/meta.dart';
 
 import '../../clients/couchdb_client.dart';
 import '../../entities/db_response.dart';
+import '../../entities/server_model_response.dart';
 import 'base_model.dart';
 
 /// Server interface provides the basic interface to a CouchDB server
@@ -24,7 +25,7 @@ abstract class ServerBaseModel extends BaseModel {
   ///   "version": "1.3.1"
   /// }
   /// ```
-  Future<DbResponse> couchDbInfo({Map<String, String> headers});
+  Future<ServerModelResponse> couchDbInfo({Map<String, String> headers});
 
   /// List of running tasks, including the task type, name, status and process ID
   ///
@@ -62,7 +63,7 @@ abstract class ServerBaseModel extends BaseModel {
   ///     }
   /// ]
   /// ```
-  Future<DbResponse> activeTasks({Map<String, String> headers});
+  Future<ServerModelResponse> activeTasks({Map<String, String> headers});
 
   /// Returns a list of all the databases in the CouchDB instance
   ///
@@ -76,7 +77,7 @@ abstract class ServerBaseModel extends BaseModel {
   ///   "locations"
   /// ]
   /// ```
-  Future<DbResponse> allDbs({Map<String, String> headers});
+  Future<ServerModelResponse> allDbs({Map<String, String> headers});
 
   /// Returns information of a list of the specified databases in the CouchDB instance
   ///
@@ -143,7 +144,7 @@ abstract class ServerBaseModel extends BaseModel {
   ///   }
   /// ]
   /// ```
-  Future<DbResponse> dbsInfo(List<String> keys);
+  Future<ServerModelResponse> dbsInfo(List<String> keys);
 
   /// Returns the status of the node or cluster, per the cluster setup wizard
   ///
@@ -158,7 +159,7 @@ abstract class ServerBaseModel extends BaseModel {
   /// - `single_node_enabled`,
   /// - `cluster_enabled`,
   /// - `cluster_finished`
-  Future<DbResponse> clusterSetupStatus(
+  Future<ServerModelResponse> clusterSetupStatus(
       {List<String> ensureDbsExist, Map<String, String> headers});
 
   /// Configure a node as a single (standalone) node, as part of a cluster, or finalise a cluster
@@ -166,7 +167,7 @@ abstract class ServerBaseModel extends BaseModel {
   /// Correspond to `POST /_cluster_setup` method.
   /// If [ensureDbsExist] isn't specified, it is defaults to `["_users","_replicator","_global_changes"]`.
   /// [bindAdress] should be provided not [host], if CouchDB is configuring as `single_node`.
-  Future<DbResponse> configureCouchDb(
+  Future<ServerModelResponse> configureCouchDb(
       {@required String action,
       @required String bindAdress,
       @required String username,
@@ -200,7 +201,7 @@ abstract class ServerBaseModel extends BaseModel {
   ///     "last_seq": "2-g1AAAAFReJzLYWBg4MhgTmHgzcvPy09JdcjLz8gvLskBCjMlMiTJ____PyuDOZEpFyjAnmJhkWaeaIquGIf2JAUgmWQPMiGRAZcaB5CaePxqEkBq6vGqyWMBkgwNQAqobD4hdQsg6vYTUncAou4-IXUPIOpA7ssCAIFHa60"
   /// }
   /// ```
-  Future<DbResponse> dbUpdates(
+  Future<ServerModelResponse> dbUpdates(
       {String feed = 'normal',
       int timeout = 60,
       int heartbeat = 60000,
@@ -224,7 +225,7 @@ abstract class ServerBaseModel extends BaseModel {
   ///     ]
   /// }
   /// ```
-  Future<DbResponse> membership({Map<String, String> headers});
+  Future<ServerModelResponse> membership({Map<String, String> headers});
 
   /// Request, configure, or stop, a replication operation
   ///
@@ -265,7 +266,7 @@ abstract class ServerBaseModel extends BaseModel {
   ///     "source_last_seq": 28
   /// }
   /// ```
-  Future<DbResponse> replicate(
+  Future<ServerModelResponse> replicate(
       {bool cancel,
       bool continuous,
       bool createTarget,
@@ -308,7 +309,7 @@ abstract class ServerBaseModel extends BaseModel {
   ///     "total_rows": 2
   ///  }
   /// ```
-  Future<DbResponse> schedulerJobs({int limit, int skip});
+  Future<ServerModelResponse> schedulerJobs({int limit, int skip});
 
   /// List of replication document states
   ///
@@ -335,7 +336,7 @@ abstract class ServerBaseModel extends BaseModel {
   ///     "total_rows": 2
   /// }
   /// ```
-  Future<DbResponse> schedulerDocs({int limit, int skip});
+  Future<ServerModelResponse> schedulerDocs({int limit, int skip});
 
   /// Gets information about replication documents from a [replicator] database
   ///
@@ -365,7 +366,7 @@ abstract class ServerBaseModel extends BaseModel {
   ///     "total_rows": 1
   /// }
   /// ```
-  Future<DbResponse> schedulerDocsWithReplicatorDbName(
+  Future<ServerModelResponse> schedulerDocsWithReplicatorDbName(
       {String replicator = '_replicator', int limit, int skip});
 
   /// Gets information about replication document from a [replicator] database
@@ -390,7 +391,7 @@ abstract class ServerBaseModel extends BaseModel {
   ///     "target": "http://adm:*****@localhost:15984/cdyno-0000002/"
   /// }
   /// ```
-  Future<DbResponse> schedulerDocsWithDocId(String docId,
+  Future<ServerModelResponse> schedulerDocsWithDocId(String docId,
       {String replicator = '_replicator'});
 
   /// Returns a JSON object containing the statistics for the running server
@@ -460,7 +461,7 @@ abstract class ServerBaseModel extends BaseModel {
   ///   "desc": "length of a request inside CouchDB without MochiWeb"
   /// }
   /// ```
-  Future<DbResponse> nodeStats(
+  Future<ServerModelResponse> nodeStats(
       {String nodeName = '_local',
       String statisticSection,
       String statisticId,
@@ -469,7 +470,7 @@ abstract class ServerBaseModel extends BaseModel {
   /// Returns a JSON object containing various system-level statistics for the running server
   ///
   /// **These statistics are generally intended for CouchDB developers only.**
-  Future<DbResponse> systemStatsForNode(
+  Future<ServerModelResponse> systemStatsForNode(
       {String nodeName = '_local', Map<String, String> headers});
 
   // /// Accesses the built-in Fauxton administration interface for CouchDB.
@@ -483,7 +484,7 @@ abstract class ServerBaseModel extends BaseModel {
   /// ```json
   /// {"status": "ok"}
   /// ```
-  Future<DbResponse> up();
+  Future<ServerModelResponse> up();
 
   /// Requests one or more Universally Unique Identifiers (UUIDs) from the CouchDB instance
   ///
@@ -504,7 +505,7 @@ abstract class ServerBaseModel extends BaseModel {
   ///     ]
   /// }
   /// ```
-  Future<DbResponse> uuids({int count = 1, Map<String, String> headers});
+  Future<ServerModelResponse> uuids({int count = 1, Map<String, String> headers});
 
   // /// Binary content for the favicon.ico site icon
   // /// Returns 'Not found' if favicon isn't exist.

--- a/lib/src/models/database_model.dart
+++ b/lib/src/models/database_model.dart
@@ -4,6 +4,7 @@ import 'package:meta/meta.dart';
 
 import '../clients/couchdb_client.dart';
 import '../entities/db_response.dart';
+import '../entities/database_model_response.dart';
 import '../exceptions/couchdb_exception.dart';
 import '../utils/includer_path.dart';
 import 'base/database_base_model.dart';
@@ -15,7 +16,7 @@ class DatabaseModel extends DatabaseBaseModel {
   DatabaseModel(CouchDbClient client) : super(client);
 
   @override
-  Future<DbResponse> headDbInfo(String dbName) async {
+  Future<DatabaseModelResponse> headDbInfo(String dbName) async {
     DbResponse info;
     try {
       info = await client.head(dbName);
@@ -26,22 +27,22 @@ class DatabaseModel extends DatabaseBaseModel {
       }).errorResponse();
       rethrow;
     }
-    return info;
+    return info.databaseModelResponse();
   }
 
   @override
-  Future<DbResponse> dbInfo(String dbName) async {
+  Future<DatabaseModelResponse> dbInfo(String dbName) async {
     DbResponse info;
     try {
       info = await client.get(dbName);
     } on CouchDbException {
       rethrow;
     }
-    return info;
+    return info.databaseModelResponse();
   }
 
   @override
-  Future<DbResponse> createDb(String dbName, {int q = 8}) async {
+  Future<DatabaseModelResponse> createDb(String dbName, {int q = 8}) async {
     final regexp = RegExp(r'^[a-z][a-z0-9_$()+/-]*$');
     DbResponse result;
 
@@ -60,11 +61,11 @@ class DatabaseModel extends DatabaseBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.databaseModelResponse();
   }
 
   @override
-  Future<DbResponse> deleteDb(String dbName) async {
+  Future<DatabaseModelResponse> deleteDb(String dbName) async {
     DbResponse result;
 
     try {
@@ -72,11 +73,11 @@ class DatabaseModel extends DatabaseBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.databaseModelResponse();
   }
 
   @override
-  Future<DbResponse> createDocIn(String dbName, Map<String, Object> doc,
+  Future<DatabaseModelResponse> createDocIn(String dbName, Map<String, Object> doc,
       {String batch, Map<String, String> headers}) async {
     DbResponse result;
 
@@ -87,11 +88,11 @@ class DatabaseModel extends DatabaseBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.databaseModelResponse();
   }
 
   @override
-  Future<DbResponse> allDocs(String dbName, {bool includeDocs = false}) async {
+  Future<DatabaseModelResponse> allDocs(String dbName, {bool includeDocs = false}) async {
     DbResponse result;
 
     try {
@@ -99,11 +100,11 @@ class DatabaseModel extends DatabaseBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.databaseModelResponse();
   }
 
   @override
-  Future<DbResponse> docsByKeys(String dbName, {List<String> keys}) async {
+  Future<DatabaseModelResponse> docsByKeys(String dbName, {List<String> keys}) async {
     DbResponse result;
 
     final body = <String, List<String>>{'keys': keys};
@@ -115,11 +116,11 @@ class DatabaseModel extends DatabaseBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.databaseModelResponse();
   }
 
   @override
-  Future<DbResponse> allDesignDocs(String dbName,
+  Future<DatabaseModelResponse> allDesignDocs(String dbName,
       {bool conflicts = false,
       bool descending = false,
       String endKey,
@@ -148,11 +149,11 @@ class DatabaseModel extends DatabaseBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.databaseModelResponse();
   }
 
   @override
-  Future<DbResponse> designDocsByKeys(String dbName, List<String> keys) async {
+  Future<DatabaseModelResponse> designDocsByKeys(String dbName, List<String> keys) async {
     DbResponse result;
 
     final body = <String, List<String>>{'keys': keys};
@@ -162,11 +163,11 @@ class DatabaseModel extends DatabaseBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.databaseModelResponse();
   }
 
   @override
-  Future<DbResponse> queriesDocsFrom(
+  Future<DatabaseModelResponse> queriesDocsFrom(
       String dbName, List<Map<String, Object>> queries) async {
     DbResponse result;
 
@@ -177,11 +178,11 @@ class DatabaseModel extends DatabaseBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.databaseModelResponse();
   }
 
   @override
-  Future<DbResponse> bulkDocs(String dbName, List<Object> docs,
+  Future<DatabaseModelResponse> bulkDocs(String dbName, List<Object> docs,
       {@required bool revs}) async {
     DbResponse result;
 
@@ -192,11 +193,11 @@ class DatabaseModel extends DatabaseBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.databaseModelResponse();
   }
 
   @override
-  Future<DbResponse> insertBulkDocs(String dbName, List<Object> docs,
+  Future<DatabaseModelResponse> insertBulkDocs(String dbName, List<Object> docs,
       {bool newEdits = true, Map<String, String> headers}) async {
     DbResponse result;
 
@@ -208,11 +209,11 @@ class DatabaseModel extends DatabaseBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.databaseModelResponse();
   }
 
   @override
-  Future<DbResponse> find(String dbName, Map<String, Object> selector,
+  Future<DatabaseModelResponse> find(String dbName, Map<String, Object> selector,
       {int limit = 25,
       int skip,
       List<Object> sort,
@@ -256,11 +257,11 @@ class DatabaseModel extends DatabaseBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.databaseModelResponse();
   }
 
   @override
-  Future<DbResponse> createIndexIn(String dbName,
+  Future<DatabaseModelResponse> createIndexIn(String dbName,
       {@required List<String> indexFields,
       String ddoc,
       String name,
@@ -287,11 +288,11 @@ class DatabaseModel extends DatabaseBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.databaseModelResponse();
   }
 
   @override
-  Future<DbResponse> indexesAt(String dbName) async {
+  Future<DatabaseModelResponse> indexesAt(String dbName) async {
     DbResponse result;
 
     try {
@@ -299,11 +300,11 @@ class DatabaseModel extends DatabaseBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.databaseModelResponse();
   }
 
   @override
-  Future<DbResponse> deleteIndexIn(
+  Future<DatabaseModelResponse> deleteIndexIn(
       String dbName, String designDoc, String name) async {
     DbResponse result;
 
@@ -312,11 +313,11 @@ class DatabaseModel extends DatabaseBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.databaseModelResponse();
   }
 
   @override
-  Future<DbResponse> explain(String dbName, Map<String, Object> selector,
+  Future<DatabaseModelResponse> explain(String dbName, Map<String, Object> selector,
       {int limit = 25,
       int skip,
       List<Object> sort,
@@ -360,11 +361,11 @@ class DatabaseModel extends DatabaseBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.databaseModelResponse();
   }
 
   @override
-  Future<DbResponse> shards(String dbName) async {
+  Future<DatabaseModelResponse> shards(String dbName) async {
     DbResponse result;
 
     try {
@@ -372,11 +373,11 @@ class DatabaseModel extends DatabaseBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.databaseModelResponse();
   }
 
   @override
-  Future<DbResponse> shard(String dbName, String docId) async {
+  Future<DatabaseModelResponse> shard(String dbName, String docId) async {
     DbResponse result;
 
     try {
@@ -384,11 +385,11 @@ class DatabaseModel extends DatabaseBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.databaseModelResponse();
   }
 
   @override
-  Future<DbResponse> synchronizeShards(String dbName) async {
+  Future<DatabaseModelResponse> synchronizeShards(String dbName) async {
     DbResponse result;
 
     try {
@@ -396,7 +397,7 @@ class DatabaseModel extends DatabaseBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.databaseModelResponse();
   }
 
   @override
@@ -528,7 +529,7 @@ class DatabaseModel extends DatabaseBaseModel {
   }
 
   @override
-  Future<DbResponse> compact(String dbName) async {
+  Future<DatabaseModelResponse> compact(String dbName) async {
     DbResponse result;
 
     try {
@@ -536,11 +537,11 @@ class DatabaseModel extends DatabaseBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.databaseModelResponse();
   }
 
   @override
-  Future<DbResponse> compactViewIndexesWith(
+  Future<DatabaseModelResponse> compactViewIndexesWith(
       String dbName, String ddocName) async {
     DbResponse result;
 
@@ -549,11 +550,11 @@ class DatabaseModel extends DatabaseBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.databaseModelResponse();
   }
 
   @override
-  Future<DbResponse> ensureFullCommit(String dbName) async {
+  Future<DatabaseModelResponse> ensureFullCommit(String dbName) async {
     DbResponse result;
 
     try {
@@ -561,11 +562,11 @@ class DatabaseModel extends DatabaseBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.databaseModelResponse();
   }
 
   @override
-  Future<DbResponse> viewCleanup(String dbName) async {
+  Future<DatabaseModelResponse> viewCleanup(String dbName) async {
     DbResponse result;
 
     try {
@@ -573,11 +574,11 @@ class DatabaseModel extends DatabaseBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.databaseModelResponse();
   }
 
   @override
-  Future<DbResponse> securityOf(String dbName) async {
+  Future<DatabaseModelResponse> securityOf(String dbName) async {
     DbResponse result;
 
     try {
@@ -585,11 +586,11 @@ class DatabaseModel extends DatabaseBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.databaseModelResponse();
   }
 
   @override
-  Future<DbResponse> setSecurityFor(
+  Future<DatabaseModelResponse> setSecurityFor(
       String dbName, Map<String, Map<String, List<String>>> security) async {
     DbResponse result;
 
@@ -598,11 +599,11 @@ class DatabaseModel extends DatabaseBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.databaseModelResponse();
   }
 
   @override
-  Future<DbResponse> purge(
+  Future<DatabaseModelResponse> purge(
       String dbName, Map<String, List<String>> docs) async {
     DbResponse result;
 
@@ -611,11 +612,11 @@ class DatabaseModel extends DatabaseBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.databaseModelResponse();
   }
 
   @override
-  Future<DbResponse> purgedInfosLimit(String dbName) async {
+  Future<DatabaseModelResponse> purgedInfosLimit(String dbName) async {
     DbResponse result;
 
     try {
@@ -623,11 +624,11 @@ class DatabaseModel extends DatabaseBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.databaseModelResponse();
   }
 
   @override
-  Future<DbResponse> setPurgedInfosLimit(String dbName, int limit) async {
+  Future<DatabaseModelResponse> setPurgedInfosLimit(String dbName, int limit) async {
     DbResponse result;
 
     try {
@@ -635,11 +636,11 @@ class DatabaseModel extends DatabaseBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.databaseModelResponse();
   }
 
   @override
-  Future<DbResponse> missingRevs(
+  Future<DatabaseModelResponse> missingRevs(
       String dbName, Map<String, List<String>> revs) async {
     DbResponse result;
 
@@ -648,11 +649,11 @@ class DatabaseModel extends DatabaseBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.databaseModelResponse();
   }
 
   @override
-  Future<DbResponse> revsDiff(
+  Future<DatabaseModelResponse> revsDiff(
       String dbName, Map<String, List<String>> revs) async {
     DbResponse result;
 
@@ -661,11 +662,11 @@ class DatabaseModel extends DatabaseBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.databaseModelResponse();
   }
 
   @override
-  Future<DbResponse> revsLimitOf(String dbName) async {
+  Future<DatabaseModelResponse> revsLimitOf(String dbName) async {
     DbResponse result;
 
     try {
@@ -673,13 +674,13 @@ class DatabaseModel extends DatabaseBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.databaseModelResponse();
   }
 
   /// Sets the maximum number of document revisions that will be tracked by CouchDB,
   /// even after compaction has occurred
   @override
-  Future<DbResponse> setRevsLimit(String dbName, int limit) async {
+  Future<DatabaseModelResponse> setRevsLimit(String dbName, int limit) async {
     DbResponse result;
 
     try {
@@ -687,6 +688,6 @@ class DatabaseModel extends DatabaseBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.databaseModelResponse();
   }
 }

--- a/lib/src/models/design_document_model.dart
+++ b/lib/src/models/design_document_model.dart
@@ -2,6 +2,7 @@ import 'package:meta/meta.dart';
 
 import '../clients/couchdb_client.dart';
 import '../entities/db_response.dart';
+import '../entities/design_document_model_response.dart';
 import '../exceptions/couchdb_exception.dart';
 import '../utils/includer_path.dart';
 import 'base/design_document_base_model.dart';
@@ -12,7 +13,7 @@ class DesignDocumentModel extends DesignDocumentBaseModel {
   DesignDocumentModel(CouchDbClient client) : super(client);
 
   @override
-  Future<DbResponse> designDocHeaders(String dbName, String ddocId,
+  Future<DesignDocumentModelResponse> designDocHeaders(String dbName, String ddocId,
       {Map<String, String> headers,
       bool attachments = false,
       bool attEncodingInfo = false,
@@ -39,11 +40,11 @@ class DesignDocumentModel extends DesignDocumentBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.designDocumentModelResponse();
   }
 
   @override
-  Future<DbResponse> designDoc(String dbName, String ddocId,
+  Future<DesignDocumentModelResponse> designDoc(String dbName, String ddocId,
       {Map<String, String> headers,
       bool attachments = false,
       bool attEncodingInfo = false,
@@ -70,11 +71,11 @@ class DesignDocumentModel extends DesignDocumentBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.designDocumentModelResponse();
   }
 
   @override
-  Future<DbResponse> insertDesignDoc(
+  Future<DesignDocumentModelResponse> insertDesignDoc(
       String dbName, String ddocId, Map<String, Object> body,
       {Map<String, String> headers,
       String rev,
@@ -91,11 +92,11 @@ class DesignDocumentModel extends DesignDocumentBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.designDocumentModelResponse();
   }
 
   @override
-  Future<DbResponse> deleteDesignDoc(String dbName, String ddocId, String rev,
+  Future<DesignDocumentModelResponse> deleteDesignDoc(String dbName, String ddocId, String rev,
       {Map<String, String> headers, String batch}) async {
     DbResponse result;
 
@@ -107,11 +108,11 @@ class DesignDocumentModel extends DesignDocumentBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.designDocumentModelResponse();
   }
 
   @override
-  Future<DbResponse> copyDesignDoc(String dbName, String ddocId,
+  Future<DesignDocumentModelResponse> copyDesignDoc(String dbName, String ddocId,
       {Map<String, String> headers, String rev, String batch}) async {
     DbResponse result;
 
@@ -123,11 +124,11 @@ class DesignDocumentModel extends DesignDocumentBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.designDocumentModelResponse();
   }
 
   @override
-  Future<DbResponse> attachmentInfo(
+  Future<DesignDocumentModelResponse> attachmentInfo(
       String dbName, String ddocId, String attName,
       {Map<String, String> headers, String rev}) async {
     DbResponse result;
@@ -139,11 +140,11 @@ class DesignDocumentModel extends DesignDocumentBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.designDocumentModelResponse();
   }
 
   @override
-  Future<DbResponse> attachment(String dbName, String ddocId, String attName,
+  Future<DesignDocumentModelResponse> attachment(String dbName, String ddocId, String attName,
       {Map<String, String> headers, String rev}) async {
     DbResponse result;
 
@@ -154,11 +155,11 @@ class DesignDocumentModel extends DesignDocumentBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.designDocumentModelResponse();
   }
 
   @override
-  Future<DbResponse> uploadAttachment(
+  Future<DesignDocumentModelResponse> uploadAttachment(
       String dbName, String ddocId, String attName, Object body,
       {Map<String, String> headers, String rev}) async {
     DbResponse result;
@@ -170,11 +171,11 @@ class DesignDocumentModel extends DesignDocumentBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.designDocumentModelResponse();
   }
 
   @override
-  Future<DbResponse> deleteAttachment(
+  Future<DesignDocumentModelResponse> deleteAttachment(
       String dbName, String ddocId, String attName,
       {@required String rev, Map<String, String> headers, String batch}) async {
     DbResponse result;
@@ -187,11 +188,11 @@ class DesignDocumentModel extends DesignDocumentBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.designDocumentModelResponse();
   }
 
   @override
-  Future<DbResponse> designDocInfo(String dbName, String ddocId,
+  Future<DesignDocumentModelResponse> designDocInfo(String dbName, String ddocId,
       {Map<String, String> headers}) async {
     DbResponse result;
 
@@ -202,11 +203,11 @@ class DesignDocumentModel extends DesignDocumentBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.designDocumentModelResponse();
   }
 
   @override
-  Future<DbResponse> executeViewFunction(
+  Future<DesignDocumentModelResponse> executeViewFunction(
       String dbName, String ddocId, String viewName,
       {bool conflicts = false,
       bool descending = false,
@@ -262,11 +263,11 @@ class DesignDocumentModel extends DesignDocumentBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.designDocumentModelResponse();
   }
 
   @override
-  Future<DbResponse> executeViewFunctionWithKeys(
+  Future<DesignDocumentModelResponse> executeViewFunctionWithKeys(
       String dbName, String ddocId, String viewName,
       {@required List<Object> keys,
       bool conflicts = false,
@@ -324,11 +325,11 @@ class DesignDocumentModel extends DesignDocumentBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.designDocumentModelResponse();
   }
 
   @override
-  Future<DbResponse> executeViewQueries(String dbName, String ddocId,
+  Future<DesignDocumentModelResponse> executeViewQueries(String dbName, String ddocId,
       String viewName, List<Object> queries) async {
     DbResponse result;
 
@@ -340,11 +341,11 @@ class DesignDocumentModel extends DesignDocumentBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.designDocumentModelResponse();
   }
 
   @override
-  Future<DbResponse> executeShowFunctionForNull(
+  Future<DesignDocumentModelResponse> executeShowFunctionForNull(
       String dbName, String ddocId, String funcName,
       {String format}) async {
     DbResponse result;
@@ -355,11 +356,11 @@ class DesignDocumentModel extends DesignDocumentBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.designDocumentModelResponse();
   }
 
   @override
-  Future<DbResponse> executeShowFunctionForDocument(
+  Future<DesignDocumentModelResponse> executeShowFunctionForDocument(
       String dbName, String ddocId, String funcName, String docId,
       {String format}) async {
     DbResponse result;
@@ -370,11 +371,11 @@ class DesignDocumentModel extends DesignDocumentBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.designDocumentModelResponse();
   }
 
   @override
-  Future<DbResponse> executeListFunctionForView(
+  Future<DesignDocumentModelResponse> executeListFunctionForView(
       String dbName, String ddocId, String funcName, String view,
       {String format}) async {
     DbResponse result;
@@ -385,11 +386,11 @@ class DesignDocumentModel extends DesignDocumentBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.designDocumentModelResponse();
   }
 
   @override
-  Future<DbResponse> executeListFunctionForViewFromDoc(String dbName,
+  Future<DesignDocumentModelResponse> executeListFunctionForViewFromDoc(String dbName,
       String ddocId, String funcName, String otherDoc, String view,
       {String format}) async {
     DbResponse result;
@@ -400,11 +401,11 @@ class DesignDocumentModel extends DesignDocumentBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.designDocumentModelResponse();
   }
 
   @override
-  Future<DbResponse> executeUpdateFunctionForNull(
+  Future<DesignDocumentModelResponse> executeUpdateFunctionForNull(
       String dbName, String ddocId, String funcName, Object body) async {
     DbResponse result;
 
@@ -414,11 +415,11 @@ class DesignDocumentModel extends DesignDocumentBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.designDocumentModelResponse();
   }
 
   @override
-  Future<DbResponse> executeUpdateFunctionForDocument(String dbName,
+  Future<DesignDocumentModelResponse> executeUpdateFunctionForDocument(String dbName,
       String ddocId, String funcName, String docId, Object body) async {
     DbResponse result;
 
@@ -428,11 +429,11 @@ class DesignDocumentModel extends DesignDocumentBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.designDocumentModelResponse();
   }
 
   @override
-  Future<DbResponse> rewritePath(
+  Future<DesignDocumentModelResponse> rewritePath(
     String dbName,
     String ddocId,
     String path,
@@ -444,6 +445,6 @@ class DesignDocumentModel extends DesignDocumentBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.designDocumentModelResponse();
   }
 }

--- a/lib/src/models/document_model.dart
+++ b/lib/src/models/document_model.dart
@@ -2,6 +2,7 @@ import 'package:meta/meta.dart';
 
 import '../clients/couchdb_client.dart';
 import '../entities/db_response.dart';
+import '../entities/document_model_response.dart';
 import '../exceptions/couchdb_exception.dart';
 import '../utils/includer_path.dart';
 import 'base/document_base_model.dart';
@@ -12,7 +13,7 @@ class DocumentModel extends DocumentBaseModel {
   DocumentModel(CouchDbClient client) : super(client);
 
   @override
-  Future<DbResponse> docInfo(String dbName, String docId,
+  Future<DocumentModelResponse> docInfo(String dbName, String docId,
       {Map<String, String> headers,
       bool attachments = false,
       bool attEncodingInfo = false,
@@ -39,11 +40,11 @@ class DocumentModel extends DocumentBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.documentModelResponse();
   }
 
   @override
-  Future<DbResponse> doc(String dbName, String docId,
+  Future<DocumentModelResponse> doc(String dbName, String docId,
       {Map<String, String> headers,
       bool attachments = false,
       bool attEncodingInfo = false,
@@ -70,11 +71,11 @@ class DocumentModel extends DocumentBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.documentModelResponse();
   }
 
   @override
-  Future<DbResponse> insertDoc(
+  Future<DocumentModelResponse> insertDoc(
       String dbName, String docId, Map<String, Object> body,
       {Map<String, String> headers,
       String rev,
@@ -91,11 +92,11 @@ class DocumentModel extends DocumentBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.documentModelResponse();
   }
 
   @override
-  Future<DbResponse> deleteDoc(String dbName, String docId, String rev,
+  Future<DocumentModelResponse> deleteDoc(String dbName, String docId, String rev,
       {Map<String, String> headers, String batch}) async {
     DbResponse result;
 
@@ -107,11 +108,11 @@ class DocumentModel extends DocumentBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.documentModelResponse();
   }
 
   @override
-  Future<DbResponse> copyDoc(String dbName, String docId,
+  Future<DocumentModelResponse> copyDoc(String dbName, String docId,
       {Map<String, String> headers, String rev, String batch}) async {
     DbResponse result;
 
@@ -123,11 +124,11 @@ class DocumentModel extends DocumentBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.documentModelResponse();
   }
 
   @override
-  Future<DbResponse> attachmentInfo(String dbName, String docId, String attName,
+  Future<DocumentModelResponse> attachmentInfo(String dbName, String docId, String attName,
       {Map<String, String> headers, String rev}) async {
     DbResponse result;
 
@@ -138,11 +139,11 @@ class DocumentModel extends DocumentBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.documentModelResponse();
   }
 
   @override
-  Future<DbResponse> attachment(String dbName, String docId, String attName,
+  Future<DocumentModelResponse> attachment(String dbName, String docId, String attName,
       {Map<String, String> headers, String rev}) async {
     DbResponse result;
 
@@ -153,11 +154,11 @@ class DocumentModel extends DocumentBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.documentModelResponse();
   }
 
   @override
-  Future<DbResponse> uploadAttachment(
+  Future<DocumentModelResponse> uploadAttachment(
       String dbName, String docId, String attName, Object body,
       {Map<String, String> headers, String rev}) async {
     DbResponse result;
@@ -169,11 +170,11 @@ class DocumentModel extends DocumentBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.documentModelResponse();
   }
 
   @override
-  Future<DbResponse> deleteAttachment(
+  Future<DocumentModelResponse> deleteAttachment(
       String dbName, String docId, String attName,
       {@required String rev, Map<String, String> headers, String batch}) async {
     DbResponse result;
@@ -186,6 +187,6 @@ class DocumentModel extends DocumentBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.documentModelResponse();
   }
 }

--- a/lib/src/models/local_document_model.dart
+++ b/lib/src/models/local_document_model.dart
@@ -2,6 +2,7 @@ import 'package:meta/meta.dart';
 
 import '../clients/couchdb_client.dart';
 import '../entities/db_response.dart';
+import '../entities/local_document_model_response.dart';
 import '../exceptions/couchdb_exception.dart';
 import '../utils/includer_path.dart';
 import 'base/local_document_base_model.dart';
@@ -13,7 +14,7 @@ class LocalDocumentModel extends LocalDocumentBaseModel {
   LocalDocumentModel(CouchDbClient client) : super(client);
 
   @override
-  Future<DbResponse> localDocs(String dbName,
+  Future<LocalDocumentModelResponse> localDocs(String dbName,
       {bool conflicts = false,
       bool descending = false,
       String endKey,
@@ -43,11 +44,11 @@ class LocalDocumentModel extends LocalDocumentBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.localDocumentModelResponse();
   }
 
   @override
-  Future<DbResponse> localDocsWithKeys(String dbName,
+  Future<LocalDocumentModelResponse> localDocsWithKeys(String dbName,
       {@required List<String> keys,
       bool conflicts = false,
       bool descending = false,
@@ -77,11 +78,11 @@ class LocalDocumentModel extends LocalDocumentBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.localDocumentModelResponse();
   }
 
   @override
-  Future<DbResponse> localDoc(String dbName, String docId,
+  Future<LocalDocumentModelResponse> localDoc(String dbName, String docId,
       {Map<String, String> headers,
       bool conflicts = false,
       bool deletedConflicts = false,
@@ -104,11 +105,11 @@ class LocalDocumentModel extends LocalDocumentBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.localDocumentModelResponse();
   }
 
   @override
-  Future<DbResponse> putLocalDoc(
+  Future<LocalDocumentModelResponse> putLocalDoc(
       String dbName, String docId, Map<String, Object> body,
       {Map<String, String> headers,
       String rev,
@@ -125,11 +126,11 @@ class LocalDocumentModel extends LocalDocumentBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.localDocumentModelResponse();
   }
 
   @override
-  Future<DbResponse> deleteLocalDoc(String dbName, String docId, String rev,
+  Future<LocalDocumentModelResponse> deleteLocalDoc(String dbName, String docId, String rev,
       {Map<String, String> headers, String batch}) async {
     DbResponse result;
 
@@ -141,11 +142,11 @@ class LocalDocumentModel extends LocalDocumentBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.localDocumentModelResponse();
   }
 
   @override
-  Future<DbResponse> copyLocalDoc(String dbName, String docId,
+  Future<LocalDocumentModelResponse> copyLocalDoc(String dbName, String docId,
       {Map<String, String> headers, String rev, String batch}) async {
     DbResponse result;
 
@@ -157,6 +158,6 @@ class LocalDocumentModel extends LocalDocumentBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.localDocumentModelResponse();
   }
 }

--- a/lib/src/models/server_model.dart
+++ b/lib/src/models/server_model.dart
@@ -2,6 +2,7 @@ import 'package:meta/meta.dart';
 
 import '../clients/couchdb_client.dart';
 import '../entities/db_response.dart';
+import '../entities/server_model_response.dart';
 import '../exceptions/couchdb_exception.dart';
 // import '../utils/browser_runner.dart';
 import '../utils/includer_path.dart';
@@ -14,7 +15,7 @@ class ServerModel extends ServerBaseModel {
   ServerModel(CouchDbClient client) : super(client);
 
   @override
-  Future<DbResponse> couchDbInfo({Map<String, String> headers}) async {
+  Future<ServerModelResponse> couchDbInfo({Map<String, String> headers}) async {
     DbResponse result;
 
     try {
@@ -22,11 +23,11 @@ class ServerModel extends ServerBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.serverModelResponse();
   }
 
   @override
-  Future<DbResponse> activeTasks({Map<String, String> headers}) async {
+  Future<ServerModelResponse> activeTasks({Map<String, String> headers}) async {
     DbResponse result;
 
     try {
@@ -34,11 +35,11 @@ class ServerModel extends ServerBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.serverModelResponse();
   }
 
   @override
-  Future<DbResponse> allDbs({Map<String, String> headers}) async {
+  Future<ServerModelResponse> allDbs({Map<String, String> headers}) async {
     DbResponse result;
 
     try {
@@ -46,11 +47,11 @@ class ServerModel extends ServerBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.serverModelResponse();
   }
 
   @override
-  Future<DbResponse> dbsInfo(List<String> keys) async {
+  Future<ServerModelResponse> dbsInfo(List<String> keys) async {
     DbResponse result;
 
     final body = <String, List<String>>{'keys': keys};
@@ -60,11 +61,11 @@ class ServerModel extends ServerBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.serverModelResponse();
   }
 
   @override
-  Future<DbResponse> clusterSetupStatus(
+  Future<ServerModelResponse> clusterSetupStatus(
       {List<String> ensureDbsExist, Map<String, String> headers}) async {
     DbResponse result;
 
@@ -75,11 +76,11 @@ class ServerModel extends ServerBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.serverModelResponse();
   }
 
   @override
-  Future<DbResponse> configureCouchDb(
+  Future<ServerModelResponse> configureCouchDb(
       {@required String action,
       String bindAdress,
       String username,
@@ -132,11 +133,11 @@ class ServerModel extends ServerBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.serverModelResponse();
   }
 
   @override
-  Future<DbResponse> dbUpdates(
+  Future<ServerModelResponse> dbUpdates(
       {String feed = 'normal',
       int timeout = 60,
       int heartbeat = 60000,
@@ -157,11 +158,11 @@ class ServerModel extends ServerBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.serverModelResponse();
   }
 
   @override
-  Future<DbResponse> membership({Map<String, String> headers}) async {
+  Future<ServerModelResponse> membership({Map<String, String> headers}) async {
     DbResponse result;
 
     try {
@@ -169,11 +170,11 @@ class ServerModel extends ServerBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.serverModelResponse();
   }
 
   @override
-  Future<DbResponse> replicate(
+  Future<ServerModelResponse> replicate(
       {bool cancel,
       bool continuous,
       bool createTarget,
@@ -216,11 +217,11 @@ class ServerModel extends ServerBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.serverModelResponse();
   }
 
   @override
-  Future<DbResponse> schedulerJobs({int limit, int skip}) async {
+  Future<ServerModelResponse> schedulerJobs({int limit, int skip}) async {
     DbResponse result;
 
     try {
@@ -229,11 +230,11 @@ class ServerModel extends ServerBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.serverModelResponse();
   }
 
   @override
-  Future<DbResponse> schedulerDocs({int limit, int skip}) async {
+  Future<ServerModelResponse> schedulerDocs({int limit, int skip}) async {
     DbResponse result;
 
     try {
@@ -242,11 +243,11 @@ class ServerModel extends ServerBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.serverModelResponse();
   }
 
   @override
-  Future<DbResponse> schedulerDocsWithReplicatorDbName(
+  Future<ServerModelResponse> schedulerDocsWithReplicatorDbName(
       {String replicator = '_replicator', int limit, int skip}) async {
     DbResponse result;
 
@@ -256,11 +257,11 @@ class ServerModel extends ServerBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.serverModelResponse();
   }
 
   @override
-  Future<DbResponse> schedulerDocsWithDocId(String docId,
+  Future<ServerModelResponse> schedulerDocsWithDocId(String docId,
       {String replicator = '_replicator'}) async {
     DbResponse result;
 
@@ -269,11 +270,11 @@ class ServerModel extends ServerBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.serverModelResponse();
   }
 
   @override
-  Future<DbResponse> nodeStats(
+  Future<ServerModelResponse> nodeStats(
       {String nodeName = '_local',
       String statisticSection,
       String statisticId,
@@ -289,11 +290,11 @@ class ServerModel extends ServerBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.serverModelResponse();
   }
 
   @override
-  Future<DbResponse> systemStatsForNode(
+  Future<ServerModelResponse> systemStatsForNode(
       {String nodeName = '_local', Map<String, String> headers}) async {
     DbResponse result;
 
@@ -302,7 +303,7 @@ class ServerModel extends ServerBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.serverModelResponse();
   }
 
   // @override
@@ -311,7 +312,7 @@ class ServerModel extends ServerBaseModel {
   // }
 
   @override
-  Future<DbResponse> up() async {
+  Future<ServerModelResponse> up() async {
     DbResponse result;
 
     try {
@@ -319,11 +320,11 @@ class ServerModel extends ServerBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.serverModelResponse();
   }
 
   @override
-  Future<DbResponse> uuids({int count = 1, Map<String, String> headers}) async {
+  Future<ServerModelResponse> uuids({int count = 1, Map<String, String> headers}) async {
     DbResponse result;
 
     try {
@@ -331,7 +332,7 @@ class ServerModel extends ServerBaseModel {
     } on CouchDbException {
       rethrow;
     }
-    return result;
+    return result.serverModelResponse();
   }
 
   // @override

--- a/test/couchdb_test.dart
+++ b/test/couchdb_test.dart
@@ -15,7 +15,7 @@ Future<void> main() async {
     //final r = await c.authenticate();
 
     final o = await da.shards('denta');
-    print(o.databaseModelResponse().shards);
+    print(o.shards);
   } on CouchDbException catch (e) {
     print(e);
   }


### PR DESCRIPTION
Fixes #9 

I have updated most of the methods to return the correct response type by default, by including conversion in the various class methods, as we discussed in the referenced issue.

There are two methods I didn't touch because I'm not 100% sure how they work and didn't want to break things. These are `DatabaseModel.changesIn()` and `DatabaseModel.postChangesIn()`. Someone more familiar with these methods should probably change those.