### PR TITLE
Fixed bugs in copyDoc

### DIFF
--- a/lib/src/clients/couchdb_client.dart
+++ b/lib/src/clients/couchdb_client.dart
@@ -31,7 +31,8 @@ class CouchDbClient {
       int port = 5984,
       this.auth = 'basic',
       this.cors = false,
-      String secret})
+      String secret,
+      String path})
       : secret = utf8.encode(secret != null ? secret : '') {
     if (username == null && password != null) {
       throw CouchDbException(401,
@@ -55,7 +56,7 @@ class CouchDbClient {
       host = host.replaceFirst(regExp, '');
     }
     _connectUri =
-        Uri(scheme: scheme, host: host, port: port, userInfo: userInfo);
+        Uri(scheme: scheme, host: host, port: port, userInfo: userInfo, path: path);
   }
 
   /// Create [CouchDbClient] instance from [uri] and

--- a/lib/src/clients/couchdb_client.dart
+++ b/lib/src/clients/couchdb_client.dart
@@ -295,7 +295,7 @@ class CouchDbClient {
   /// COPY method
   Future<DbResponse> copy(String path, {Map<String, String> reqHeaders}) async {
     modifyRequestHeaders(reqHeaders);
-    final request = Request('copy', Uri.parse('$origin/$path'));
+    final request = Request('COPY', Uri.parse('$origin/$path'));
     request.headers.addAll(headers);
 
     final res = await _client.send(request);

--- a/lib/src/models/base/document_base_model.dart
+++ b/lib/src/models/base/document_base_model.dart
@@ -88,7 +88,10 @@ abstract class DocumentBaseModel extends BaseModel {
       String dbName, String docId, String rev,
       {Map<String, String> headers, String batch});
 
-  /// Copies an existing document to a new or existing document
+  /// Copies an existing document to a new or existing document.
+  /// 
+  /// If you are copying to an existing document, you must specify
+  /// `destinationRev` as the current rev of the destination doc
   ///
   /// Returns JSON like:
   /// ```json
@@ -98,8 +101,8 @@ abstract class DocumentBaseModel extends BaseModel {
   ///     "rev": "1-917fa2381192822767f010b95b45325b"
   /// }
   /// ```
-  Future<DocumentModelResponse> copyDoc(String dbName, String docId,
-      {Map<String, String> headers, String rev, String batch});
+  Future<DocumentModelResponse> copyDoc(String dbName, String docId, String destinationId,
+      {Map<String, String> headers, String rev, String destinationRev, String batch});
 
   /// Returns the HTTP headers containing a minimal amount of information about the specified attachment
   Future<DocumentModelResponse> attachmentInfo(

--- a/lib/src/models/document_model.dart
+++ b/lib/src/models/document_model.dart
@@ -113,13 +113,28 @@ class DocumentModel extends DocumentBaseModel {
   }
 
   @override
-  Future<DocumentModelResponse> copyDoc(String dbName, String docId,
-      {Map<String, String> headers, String rev, String batch}) async {
+  Future<DocumentModelResponse> copyDoc(
+    String dbName, 
+    String docId, 
+    String destinationId,
+    {
+      Map<String, String> headers, 
+      String rev, 
+      String destinationRev, 
+      String batch
+    }
+  ) async {
     DbResponse result;
 
     final path = '$dbName/$docId?${includeNonNullParam('rev', rev)}&'
         '${includeNonNullParam('batch', batch)}';
+    
+    final destination = 
+        '$destinationId?${includeNonNullParam("rev", destinationRev)}';
 
+    headers ??= <String,String>{};
+    headers['Destination'] = destination;
+    
     try {
       result = await client.copy(path, reqHeaders: headers);
     } on CouchDbException {

--- a/lib/src/models/document_model.dart
+++ b/lib/src/models/document_model.dart
@@ -130,7 +130,9 @@ class DocumentModel extends DocumentBaseModel {
         '${includeNonNullParam('batch', batch)}';
     
     final destination = 
-        '$destinationId?${includeNonNullParam("rev", destinationRev)}';
+      destinationRev == null ? 
+      destinationId : 
+      '$destinationId?rev=$destinationRev';
 
     headers ??= <String,String>{};
     headers['Destination'] = destination;


### PR DESCRIPTION
I fixed some bugs in the `CouchDbClient.copy()` method and the `DocumentModel.copyDoc()` method. There were a couple problems that kept it from working:
* There was no destination parameter, so you couldn't specify where to copy to
* The HTTP server in CouchDb appears to be case sensitive, as it rejected copy requests until I capitalized 'COPY'

I also added a `path` parameter to the `CouchDbClient` constructor which will allow you to connect to couchdb via a reverse proxy on your server.