### PR TITLE
Add missing parameters to `allDocs()`

### DIFF
--- a/lib/src/models/database_model.dart
+++ b/lib/src/models/database_model.dart
@@ -94,11 +94,59 @@ class DatabaseModel extends DatabaseBaseModel {
 
   @override
   Future<DatabaseModelResponse> allDocs(String dbName,
-      {bool includeDocs = false}) async {
+      {
+        bool conflicts = false,
+        bool descending = false,
+        Object endKey,
+        String endKeyDocId,
+        bool group = false,
+        int groupLevel,
+        bool includeDocs = false,
+        bool attachments = false,
+        bool altEncodingInfo = false,
+        bool inclusiveEnd = true,
+        Object key,
+        List<Object> keys,
+        int limit,
+        bool reduce,
+        int skip,
+        bool sorted = true,
+        bool stable = false,
+        String stale,
+        Object startKey,
+        String startKeyDocId,
+        String update,
+        bool updateSeq = false
+      }
+  ) async {
     DbResponse result;
 
     try {
-      result = await client.get('$dbName/_all_docs?include_docs=$includeDocs');
+      result = await client.get(
+        '$dbName/_all_docs'
+        '?conflicts=$conflicts'
+        '&descending=$descending'
+        '&${includeNonNullJsonParam("endkey", endKey)}'
+        '&${includeNonNullParam("endkey_docid", endKeyDocId)}'
+        '&group=$group'
+        '&${includeNonNullParam("group_level", groupLevel)}'
+        '&include_docs=$includeDocs'
+        '&attachments=$attachments'
+        '&alt_encoding_info=$altEncodingInfo'
+        '&inclusive_end=$inclusiveEnd'
+        '&${includeNonNullJsonParam("key", key)}'
+        '&${includeNonNullJsonParam("keys", keys)}'
+        '&${includeNonNullParam("limit", limit)}'
+        '&${includeNonNullParam("reduce", reduce)}'
+        '&${includeNonNullParam("skip", skip)}'
+        '&sorted=$sorted'
+        '&stable=$stable'
+        '&${includeNonNullParam("stale", stale)}'
+        '&${includeNonNullJsonParam("startkey", startKey)}'
+        '&${includeNonNullParam("startkey_docid", startKeyDocId)}'
+        '&${includeNonNullParam("update", update)}'
+        '&update_seq=$updateSeq'
+      );
     } on CouchDbException {
       rethrow;
     }

--- a/lib/src/utils/includer_path.dart
+++ b/lib/src/utils/includer_path.dart
@@ -1,3 +1,15 @@
+import 'dart:convert';
+
 /// Method for including only non-null parameter to path
 String includeNonNullParam(String name, Object value) =>
     value != null ? '$name=$value' : '';
+
+/// If value != null, returns value as a JSON-encoded value, for use in a url.
+/// Otherwise returns an empty string
+/// 
+/// Some URL parameters (e.g. startkey and endkey) expect JSON-encoded
+/// values rather than bare strings. Mostly this amounts to adding
+/// quotation marks on either side of the string and escaping
+/// special characters.
+String includeNonNullJsonParam(String name, Object value) =>
+    value != null ? '$name=${jsonEncode(value)}' : '';


### PR DESCRIPTION
_all_docs is a built in view, and should have all the parameters listed [here](https://docs.couchdb.org/en/stable/api/ddoc/views.html#api-ddoc-view)